### PR TITLE
Adds `sexp` derivations for Tree.t and related types

### DIFF
--- a/lib/list1.ml
+++ b/lib/list1.ml
@@ -1,6 +1,7 @@
 open Core
 
 type 'a t = Cons of 'a * 'a list
+[@@deriving sexp]
 
 let length (Cons (_, xs)) = 1 + List.length xs
 

--- a/lib/list1.mli
+++ b/lib/list1.mli
@@ -1,4 +1,6 @@
 type 'a t = Cons of 'a * 'a list
+[@@deriving sexp]
+
 val hd : 'a t -> 'a
 val length : _ t -> int
 val singleton : 'a -> 'a t

--- a/lib/tree.ml
+++ b/lib/tree.ml
@@ -6,11 +6,11 @@ type ('n, 'l, 'b) t =
       branches : ('n, 'l, 'b) branch List1.t ;
     }
   | Leaf of 'l
-
 and ('n, 'l, 'b) branch = Branch of {
     data : 'b ;
     tip : ('n, 'l, 'b) t ;
   }
+[@@deriving sexp]
 
 let leaf l = Leaf l
 

--- a/lib/tree.mli
+++ b/lib/tree.mli
@@ -4,6 +4,7 @@ type ('n, 'l, 'b) t =
       branches : ('n, 'l, 'b) branch List1.t ;
     }
   | Leaf of 'l
+[@@deriving sexp]
 
 and ('n, 'l, 'b) branch = Branch of {
     data : 'b ;


### PR DESCRIPTION
Has a use-case for manipulating phylogenetic trees in Pelican store, and might be useful in general